### PR TITLE
Gunicorn isn't required

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ Django==1.7.1
 psycopg2==2.5.4
 django-compressor==1.4
 django-debug-toolbar==1.2.2
-gunicorn==19.1.1
 python-social-auth==0.2.2
 python-memcached==1.53


### PR DESCRIPTION
We're using Django runserver for now.  When deploying we will consider WSGI options (Apache, gunicorn) and add requirements if necessary.
