### PR TITLE
Reverted Global JS to individual includes

### DIFF
--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -17,7 +17,8 @@
     <title>{% block title %}Face It{% endblock %}</title>
     {% comment %} Core CSS includes (for inclusion on all pages) {% endcomment %}
     {% stylesheet 'css' %}
-    {% javascript 'global_js' %}
+    <script type="text/javascript" src="{% static 'bower_components/jquery/dist/jquery.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'bower_components/bootstrap/dist/js/bootstrap.min.js' %}"></script>
     <script type="text/javascript" src="{% static "js/util.min.js" %}"></script>
     <script type="text/javascript" data-app-id="{{ app_id }}" src="{% static "js/yammer_sdk.min.js" %}"></script>
     <script>

--- a/face_it/settings/base.py
+++ b/face_it/settings/base.py
@@ -127,15 +127,6 @@ PIPELINE_JS = {
         # Compress all passed files into `js/js.min.js`.
         'output_filename': 'js/js.min.js',
     },
-
-    'global_js': {
-        'source_filenames': (
-            'bower_components/jquery/dist/jquery.min.js',
-            'bower_components/bootstrap/dist/js/bootstrap.min.js',
-        ),
-        # Compress all passed files into `js/global_js.min.js`.
-        'output_filename': 'js/global_js.min.js',
-    }
     # ...
 }
 


### PR DESCRIPTION
django pipel-line is injecting the javascript in a way heroku does not seem to like. Which does not allow the scripts to load in the correct order. broke out concantenated global js file into separate script includes.
