### PR TITLE
Update redirect_uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ One difficult part of joining a new company is putting names to faces. Utilizing
 * [Register An App With Yammer](https://developer.yammer.com/v1.0/docs/app-registration)
 * **Note** the Redirect URI & Javascript Origins field
     * Dev:
-        * Redirect URI - `http://localhost:8111/auth/yammer/callback`
+        * Redirect URI - `http://localhost:8111/complete/yammer/`
         * Javascript Origins - `http://localhost:8111`
     * Production:
         * replace dev fields with respective hostname 


### PR DESCRIPTION
The redirect_uri listed in the README was not working correctly.  The proper URI is not well documented in python-social-auth, but the endpoint is [here](https://github.com/omab/python-social-auth/blob/b07708efe7d19b75009771aa97ddf821e59ec08e/social/apps/django_app/urls.py#L19)
